### PR TITLE
Backup all Gists (not last 30)

### DIFF
--- a/gist-backup
+++ b/gist-backup
@@ -14,6 +14,7 @@
 # probably have to rewrite it so that it's not shell hackery.
 
 token=$(git config --get github.gist.oauth.token)
+page=1
 
 usage() {
 cat <<END_USAGE
@@ -76,18 +77,6 @@ then
   exit 1
 fi
 
-gists=$(
-curl -s -H "Authorization: token $token" https://api.github.com/gists |
-sed -n 's/.*git_pull_url": "\(.*\)",/\1/p'
-)
-
-# curl can have an empty response for some reason...
-if [ -z "$gists" ]
-then
-  echo "No gists found."
-  exit 1
-fi
-
 # Take's a git remote URI and clones it into
 # the backup directory. If that directory
 # exists already, cd's into it and does a
@@ -107,7 +96,25 @@ backup() {
   fi
 }
 
-for gist in $gists
+while :
 do
-  backup $gist
+  echo "Requesting Gist page: $page"
+
+  gists=$(
+  curl -s -H "Authorization: token $token" -d "page=$page" -G https://api.github.com/gists |
+  sed -n 's/.*git_pull_url": "\(.*\)",/\1/p'
+  )
+
+  if [ -z "$gists" ]
+  then
+    echo "No gists found."
+    exit 1
+  fi
+
+  for gist in $gists
+  do
+    backup $gist
+  done
+
+  let "page += 1"
 done


### PR DESCRIPTION
I have 69 gists in my arsenal, but API only returns last 30, but by using GET page=N parameter you can go trough all gists. So that's what I did :)
